### PR TITLE
Fixed mssql deletes to return deleted rows

### DIFF
--- a/src/server/Generators/classes/__snapshots__/msSqlProvider.test.js.snap
+++ b/src/server/Generators/classes/__snapshots__/msSqlProvider.test.js.snap
@@ -11,7 +11,7 @@ exports[`MSSqlProvider Should generate code for configureExport that matches the
 `;
 
 exports[`MSSqlProvider Should generate code for delete that matches the snapshot 1`] = `
-"return pool.query\`DELETE FROM \\"testTable\\" WHERE \\"idCol\\" = \${args.idCol}\`
+"return pool.query\`DELETE FROM \\"testTable\\" OUTPUT DELETED.* WHERE \\"idCol\\" = \${args.idCol}\`
           .then(data => {
             return data.recordset[0];
           })

--- a/src/server/Generators/classes/msSqlProvider.js
+++ b/src/server/Generators/classes/msSqlProvider.js
@@ -45,7 +45,7 @@ class MSSqlProvider {
   }
 
   delete(table, column) {
-    let query = `return pool.query\`DELETE FROM "${table}" WHERE "${column}" = \${args.${column}}\`\n`;
+    let query = `return pool.query\`DELETE FROM "${table}" OUTPUT DELETED.* WHERE "${column}" = \${args.${column}}\`\n`;
 
     query += addPromiseResolution();
 

--- a/src/server/Generators/classes/msSqlProvider.test.js
+++ b/src/server/Generators/classes/msSqlProvider.test.js
@@ -77,7 +77,7 @@ describe("MSSqlProvider", () => {
   });
 
   it("Should generate correct sql for delete", () => {
-    const expected = `DELETE FROM "testTable" WHERE "idCol" = \${args.idCol}`;
+    const expected = `DELETE FROM "testTable" OUTPUT DELETED.* WHERE "idCol" = \${args.idCol}`;
     const result = provider.delete("testTable", "idCol");
 
     expect(result).toContain(expected);


### PR DESCRIPTION
Fixed deletes not returning data for mssql by adding an OUTPUT clause to return the deleted data. Also tested what happens when trying to delete a value that doesn't exist; a null object is returned. Tested by creating a new table in the Northwind database and deleting from it. Didn't use an existing Northwind table because all of the relationships are strongly defined. Also updated unit tests to reflect change.