### PR TITLE
Fixed delete statement to return deleted rows when delete occurs

### DIFF
--- a/src/server/Generators/__snapshots__/graphQLGenerator.test.js.snap
+++ b/src/server/Generators/__snapshots__/graphQLGenerator.test.js.snap
@@ -1035,7 +1035,7 @@ const Mutation = new GraphQLObjectType({
         id: { type: GraphQLID }
       },
       resolve(parent, args) {
-        const sql = 'DELETE FROM \\"author\\" WHERE \\"id\\" = $1';
+        const sql = 'DELETE FROM \\"author\\" WHERE \\"id\\" = $1 RETURNING *';
         return connect.conn.one(sql, args.id)
           .then(data => {
             return data;
@@ -1095,7 +1095,7 @@ const Mutation = new GraphQLObjectType({
         id: { type: GraphQLID }
       },
       resolve(parent, args) {
-        const sql = 'DELETE FROM \\"book_order\\" WHERE \\"id\\" = $1';
+        const sql = 'DELETE FROM \\"book_order\\" WHERE \\"id\\" = $1 RETURNING *';
         return connect.conn.one(sql, args.id)
           .then(data => {
             return data;
@@ -1161,7 +1161,7 @@ const Mutation = new GraphQLObjectType({
         id: { type: GraphQLID }
       },
       resolve(parent, args) {
-        const sql = 'DELETE FROM \\"books\\" WHERE \\"id\\" = $1';
+        const sql = 'DELETE FROM \\"books\\" WHERE \\"id\\" = $1 RETURNING *';
         return connect.conn.one(sql, args.id)
           .then(data => {
             return data;
@@ -1219,7 +1219,7 @@ const Mutation = new GraphQLObjectType({
         id: { type: GraphQLID }
       },
       resolve(parent, args) {
-        const sql = 'DELETE FROM \\"genre\\" WHERE \\"id\\" = $1';
+        const sql = 'DELETE FROM \\"genre\\" WHERE \\"id\\" = $1 RETURNING *';
         return connect.conn.one(sql, args.id)
           .then(data => {
             return data;
@@ -1283,7 +1283,7 @@ const Mutation = new GraphQLObjectType({
         id: { type: GraphQLID }
       },
       resolve(parent, args) {
-        const sql = 'DELETE FROM \\"order\\" WHERE \\"id\\" = $1';
+        const sql = 'DELETE FROM \\"order\\" WHERE \\"id\\" = $1 RETURNING *';
         return connect.conn.one(sql, args.id)
           .then(data => {
             return data;
@@ -1341,7 +1341,7 @@ const Mutation = new GraphQLObjectType({
         id: { type: GraphQLID }
       },
       resolve(parent, args) {
-        const sql = 'DELETE FROM \\"shipping_method\\" WHERE \\"id\\" = $1';
+        const sql = 'DELETE FROM \\"shipping_method\\" WHERE \\"id\\" = $1 RETURNING *';
         return connect.conn.one(sql, args.id)
           .then(data => {
             return data;
@@ -1399,7 +1399,7 @@ const Mutation = new GraphQLObjectType({
         id: { type: GraphQLID }
       },
       resolve(parent, args) {
-        const sql = 'DELETE FROM \\"status\\" WHERE \\"id\\" = $1';
+        const sql = 'DELETE FROM \\"status\\" WHERE \\"id\\" = $1 RETURNING *';
         return connect.conn.one(sql, args.id)
           .then(data => {
             return data;
@@ -1461,7 +1461,7 @@ const Mutation = new GraphQLObjectType({
         id: { type: GraphQLID }
       },
       resolve(parent, args) {
-        const sql = 'DELETE FROM \\"user\\" WHERE \\"id\\" = $1';
+        const sql = 'DELETE FROM \\"user\\" WHERE \\"id\\" = $1 RETURNING *';
         return connect.conn.one(sql, args.id)
           .then(data => {
             return data;

--- a/src/server/Generators/classes/pgSqlProvider.js
+++ b/src/server/Generators/classes/pgSqlProvider.js
@@ -63,7 +63,7 @@ class PgSqlProvider {
   }
 
   delete(table, column) {
-    let query = `const sql = 'DELETE FROM "${table}" WHERE "${column}" = $1';\n`;
+    let query = `const sql = 'DELETE FROM "${table}" WHERE "${column}" = $1 RETURNING *';\n`;
     query += `${tab.repeat(4)}return connect.conn.one(sql, args.${column})\n`;
 
     query += addPromiseResolution();


### PR DESCRIPTION
Added returning clause to postgres delete statement to return deleted rows.

**Note: when no rows are returned from the delete postgres throws an error while mssql just returns a null object. I initially thought about changing the pgsql functionality to match the mssql functionality but it seems like postgres throws an error whenever no rows are returned, not just on deletes. I decided to leave it as it seems to just be a function of how either the driver or postgres is written.** 

I tested the output against the sample bookstore database we have, also I updated the unit test snapshot