### PR TITLE
SWQL-30, SWQL-31 | fixed issue where spaces in table names caused build to break

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8202,9 +8202,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+      "version": "4.17.14",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.14.tgz",
+      "integrity": "sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw=="
     },
     "lodash.sortby": {
       "version": "4.7.0",

--- a/src/server/DBMetadata/__snapshots__/metadataProcessor.test.js.snap
+++ b/src/server/DBMetadata/__snapshots__/metadataProcessor.test.js.snap
@@ -4,6 +4,7 @@ exports[`Format Metadata Tests Should match the snapshot 1`] = `
 Object {
   "tables": Object {
     "0": ProcessedTable {
+      "displayName": "author",
       "fields": Array [
         ProcessedField {
           "fieldNum": 0,
@@ -37,6 +38,7 @@ Object {
       "name": "author",
     },
     "1": ProcessedTable {
+      "displayName": "book_order",
       "fields": Array [
         ProcessedField {
           "fieldNum": 0,
@@ -87,6 +89,7 @@ Object {
       "name": "book_order",
     },
     "2": ProcessedTable {
+      "displayName": "books",
       "fields": Array [
         ProcessedField {
           "fieldNum": 0,
@@ -176,6 +179,7 @@ Object {
       "name": "books",
     },
     "3": ProcessedTable {
+      "displayName": "genre",
       "fields": Array [
         ProcessedField {
           "fieldNum": 0,
@@ -209,6 +213,7 @@ Object {
       "name": "genre",
     },
     "4": ProcessedTable {
+      "displayName": "order",
       "fields": Array [
         ProcessedField {
           "fieldNum": 0,
@@ -293,6 +298,7 @@ Object {
       "name": "order",
     },
     "5": ProcessedTable {
+      "displayName": "shipping_method",
       "fields": Array [
         ProcessedField {
           "fieldNum": 0,
@@ -326,6 +332,7 @@ Object {
       "name": "shipping_method",
     },
     "6": ProcessedTable {
+      "displayName": "status",
       "fields": Array [
         ProcessedField {
           "fieldNum": 0,
@@ -359,6 +366,7 @@ Object {
       "name": "status",
     },
     "7": ProcessedTable {
+      "displayName": "user",
       "fields": Array [
         ProcessedField {
           "fieldNum": 0,

--- a/src/server/DBMetadata/classes/processedTable.js
+++ b/src/server/DBMetadata/classes/processedTable.js
@@ -2,7 +2,13 @@ const util = require("../../util");
 
 class ProcessedTable {
 	constructor (name, fields) {
-		this.name = util.removeWhitespace(name);
+		/**
+     * displayName is used for all graph ql code as the name is normalized
+     * to remove spaces, while name is used for database queries to preserve
+     * the original table name
+     */
+		this.displayName = util.removeWhitespace(name);
+		this.name = name;
 		this.fields = fields;
 	}
 

--- a/src/server/DBMetadata/sampleFiles/processedMetadata.js
+++ b/src/server/DBMetadata/sampleFiles/processedMetadata.js
@@ -1,6 +1,7 @@
 export default {
 	tables: {
 		0: {
+			displayName: "author",
 			name: "author",
 			fields: [
 				{
@@ -30,6 +31,7 @@ export default {
 			],
 		},
 		1: {
+			displayName: "book_order",
 			name: "book_order",
 			fields: [
 				{
@@ -72,6 +74,7 @@ export default {
 			],
 		},
 		2: {
+			displayName: "books",
 			name: "books",
 			fields: [
 				{
@@ -149,6 +152,7 @@ export default {
 			],
 		},
 		3: {
+			displayName: "genre",
 			name: "genre",
 			fields: [
 				{
@@ -178,6 +182,7 @@ export default {
 			],
 		},
 		4: {
+			displayName: "order",
 			name: "order",
 			fields: [
 				{
@@ -246,6 +251,7 @@ export default {
 			],
 		},
 		5: {
+			displayName: "shipping_method",
 			name: "shipping_method",
 			fields: [
 				{
@@ -275,6 +281,7 @@ export default {
 			],
 		},
 		6: {
+			displayName: "status",
 			name: "status",
 			fields: [
 				{
@@ -304,6 +311,7 @@ export default {
 			],
 		},
 		7: {
+			displayName: "user",
 			name: "user",
 			fields: [
 				{

--- a/src/server/Generators/classes/__snapshots__/msSqlProvider.test.js.snap
+++ b/src/server/Generators/classes/__snapshots__/msSqlProvider.test.js.snap
@@ -11,7 +11,7 @@ exports[`MSSqlProvider Should generate code for configureExport that matches the
 `;
 
 exports[`MSSqlProvider Should generate code for delete that matches the snapshot 1`] = `
-"return pool.query\`DELETE FROM \\"testTable\\" OUTPUT DELETED.* WHERE \\"idCol\\" = \${args.idCol}\`
+"return pool.query\`DELETE FROM [testTable] OUTPUT DELETED.* WHERE \\"idCol\\" = \${args.idCol}\`
           .then(data => {
             return data.recordset[0];
           })
@@ -21,7 +21,7 @@ exports[`MSSqlProvider Should generate code for delete that matches the snapshot
 `;
 
 exports[`MSSqlProvider Should generate code for insert that matches the snapshot 1`] = `
-"return pool.query\`INSERT INTO \\"testTable\\" (testCol) OUTPUT INSERTED.* VALUES (blah = \${parent.blah}, test = \${parent.test})\`
+"return pool.query\`INSERT INTO [testTable] (testCol) OUTPUT INSERTED.* VALUES (blah = \${parent.blah}, test = \${parent.test})\`
           .then(data => {
             return data.recordset[0];
           })
@@ -43,7 +43,7 @@ exports[`MSSqlProvider Should generate code for paramaterize that matches the sn
 `;
 
 exports[`MSSqlProvider Should generate code for select that matches the snapshot 1`] = `
-"return pool.query('SELECT * FROM \\"testTable\\"')
+"return pool.query('SELECT * FROM [testTable]')
           .then(data => {
             return data.recordset;
           })
@@ -53,7 +53,7 @@ exports[`MSSqlProvider Should generate code for select that matches the snapshot
 `;
 
 exports[`MSSqlProvider Should generate code for selectWithWhere that matches the snapshot 1`] = `
-"return pool.query\`SELECT * FROM \\"testTable\\" WHERE \\"testCol\\" = \${parent.id}\`
+"return pool.query\`SELECT * FROM [testTable] WHERE \\"testCol\\" = \${parent.id}\`
           .then(data => {
             return data.recordset[0];
           })
@@ -64,7 +64,7 @@ exports[`MSSqlProvider Should generate code for selectWithWhere that matches the
 
 exports[`MSSqlProvider Should generate code for update that matches the snapshot 1`] = `
 "        req.input('idCol', idCol);
-return req.query(\`UPDATE \\"testTable\\" SET \${parameterized} OUTPUT INSERTED.* WHERE \\"idCol\\" = @idCol\`)
+return req.query(\`UPDATE [testTable] SET \${parameterized} OUTPUT INSERTED.* WHERE \\"idCol\\" = @idCol\`)
           .then(data => {
             return data.recordset[0];
           })

--- a/src/server/Generators/classes/msSqlProvider.js
+++ b/src/server/Generators/classes/msSqlProvider.js
@@ -11,14 +11,14 @@ class MSSqlProvider {
 	}
 
 	selectWithWhere (table, col, val, returnsMany) {
-		let query = `return pool.query\`SELECT * FROM "${table}" WHERE "${col}" = \${${val}}\`\n`;
+		let query = `return pool.query\`SELECT * FROM [${table}] WHERE "${col}" = \${${val}}\`\n`;
 		query += addPromiseResolution(returnsMany);
 
 		return query;
 	}
 
 	select (table) {
-		let query = `return pool.query('SELECT * FROM "${table}"')\n`;
+		let query = `return pool.query('SELECT * FROM [${table}]')\n`;
 
 		query += addPromiseResolution(true);
 
@@ -26,7 +26,7 @@ class MSSqlProvider {
 	}
 
 	insert (table, cols, args) {
-		let query = `return pool.query\`INSERT INTO "${table}" (${cols}) OUTPUT INSERTED.* VALUES (${args})\`\n`;
+		let query = `return pool.query\`INSERT INTO [${table}] (${cols}) OUTPUT INSERTED.* VALUES (${args})\`\n`;
 
 		query += addPromiseResolution();
 
@@ -38,14 +38,14 @@ class MSSqlProvider {
 			4
 		)}req.input('${idColumnName}', ${idColumnName});\n`;
 
-		query += `return req.query(\`UPDATE "${table}" SET \${parameterized} OUTPUT INSERTED.* WHERE "${idColumnName}" = @${idColumnName}\`)\n`;
+		query += `return req.query(\`UPDATE [${table}] SET \${parameterized} OUTPUT INSERTED.* WHERE "${idColumnName}" = @${idColumnName}\`)\n`;
 
 		query += addPromiseResolution();
 		return query;
 	}
 
 	delete (table, column) {
-		let query = `return pool.query\`DELETE FROM "${table}" OUTPUT DELETED.* WHERE "${column}" = \${args.${column}}\`\n`;
+		let query = `return pool.query\`DELETE FROM [${table}] OUTPUT DELETED.* WHERE "${column}" = \${args.${column}}\`\n`;
 
 		query += addPromiseResolution();
 

--- a/src/server/Generators/classes/msSqlProvider.test.js
+++ b/src/server/Generators/classes/msSqlProvider.test.js
@@ -17,7 +17,7 @@ describe("MSSqlProvider", () => {
 	});
 
 	it("Should generate correct sql for selectWithWhere", () => {
-		const expected = `SELECT * FROM "testTable" WHERE "testCol" = \${parent.id}`;
+		const expected = `SELECT * FROM [testTable] WHERE "testCol" = \${parent.id}`;
 		const result = provider.selectWithWhere(
 			"testTable",
 			"testCol",
@@ -33,7 +33,7 @@ describe("MSSqlProvider", () => {
 	});
 
 	it("Should generate correct sql for select", () => {
-		const expected = `'SELECT * FROM "testTable"'`;
+		const expected = `'SELECT * FROM [testTable]'`;
 		const result = provider.select("testTable");
 
 		expect(result).toContain(expected);
@@ -49,7 +49,7 @@ describe("MSSqlProvider", () => {
 	});
 
 	it("Should generate correct sql for insert", () => {
-		const expected = `INSERT INTO "testTable" (col1, col2) OUTPUT INSERTED.* VALUES (blah = \${parent.blah}, test = \${parent.test})`;
+		const expected = `INSERT INTO [testTable] (col1, col2) OUTPUT INSERTED.* VALUES (blah = \${parent.blah}, test = \${parent.test})`;
 		const result = provider.insert(
 			"testTable",
 			"col1, col2",
@@ -65,7 +65,7 @@ describe("MSSqlProvider", () => {
 	});
 
 	it("Should generate correct sql for update", () => {
-		const expected = `UPDATE "testTable" SET \${parameterized} OUTPUT INSERTED.* WHERE "idCol" = @idCol`;
+		const expected = `UPDATE [testTable] SET \${parameterized} OUTPUT INSERTED.* WHERE "idCol" = @idCol`;
 		const result = provider.update("testTable", "idCol");
 
 		expect(result).toContain(expected);
@@ -77,7 +77,7 @@ describe("MSSqlProvider", () => {
 	});
 
 	it("Should generate correct sql for delete", () => {
-		const expected = `DELETE FROM "testTable" OUTPUT DELETED.* WHERE "idCol" = \${args.idCol}`;
+		const expected = `DELETE FROM [testTable] OUTPUT DELETED.* WHERE "idCol" = \${args.idCol}`;
 		const result = provider.delete("testTable", "idCol");
 
 		expect(result).toContain(expected);

--- a/src/server/Generators/classes/mutationBuilder.js
+++ b/src/server/Generators/classes/mutationBuilder.js
@@ -11,19 +11,23 @@ class MutationBuilder {
 		this.mutation += buildMutationSignature(table, null, "add");
 		this.mutation += buildTypeParams(table, null, "add");
 		this.mutation += buildReturnValues(table);
-		this.exportNames.push(`add${util.toTitleCase(table.name)}Mutation`);
+		this.exportNames.push(`add${util.toTitleCase(table.displayName)}Mutation`);
 
 		for (const field of table.fields) {
 			if (field.primaryKey) {
 				this.mutation += buildMutationSignature(table, field, "update");
 				this.mutation += buildTypeParams(table, field, "update");
 				this.mutation += buildReturnValues(table);
-				this.exportNames.push(`update${util.toTitleCase(table.name)}Mutation`);
+				this.exportNames.push(
+					`update${util.toTitleCase(table.displayName)}Mutation`
+				);
 
 				this.mutation += buildMutationSignature(table, field, "delete");
 				this.mutation += buildTypeParams(table, field, "delete");
 				this.mutation += buildReturnValues(table);
-				this.exportNames.push(`delete${util.toTitleCase(table.name)}Mutation`);
+				this.exportNames.push(
+					`delete${util.toTitleCase(table.displayName)}Mutation`
+				);
 			}
 		}
 
@@ -42,7 +46,7 @@ class MutationBuilder {
 
 function buildMutationSignature (table, idField, mutationType) {
 	let mut = `const ${mutationType}${util.toTitleCase(
-		table.name
+		table.displayName
 	)}Mutation = gql\`\n${tab}mutation(`;
 
 	if (mutationType === "delete") {
@@ -85,7 +89,7 @@ function checkRequired (required) {
 }
 
 function buildTypeParams (table, idField, mutationType) {
-	let mut = `${tab}${mutationType}${util.toTitleCase(table.name)}(`;
+	let mut = `${tab}${mutationType}${util.toTitleCase(table.displayName)}(`;
 
 	if (mutationType === "delete") {
 		mut += `${idField.name}: $${idField.name}) {\n`;

--- a/src/server/Generators/classes/queryBuilder.js
+++ b/src/server/Generators/classes/queryBuilder.js
@@ -9,12 +9,14 @@ class QueryBuilder {
 
 	addQuery (table) {
 		this.query += buildAllQuery(table);
-		this.exportNames.push(`queryEvery${util.toTitleCase(table.name)}`);
+		this.exportNames.push(`queryEvery${util.toTitleCase(table.displayName)}`);
 
 		for (const field of table.fields) {
 			if (field.primaryKey) {
 				this.query += buildQueryById(table, field);
-				this.exportNames.push(`query${util.toTitleCase(table.name)}ById `);
+				this.exportNames.push(
+					`query${util.toTitleCase(table.displayName)}ById `
+				);
 			}
 		}
 
@@ -32,9 +34,11 @@ class QueryBuilder {
 }
 
 function buildAllQuery (table) {
-	let string = `const queryEvery${util.toTitleCase(table.name)} = gql\`\n`;
+	let string = `const queryEvery${util.toTitleCase(
+		table.displayName
+	)} = gql\`\n`;
 	string += `${tab}{\n`;
-	string += `${tab.repeat(2)}every${util.toTitleCase(table.name)} {\n`;
+	string += `${tab.repeat(2)}every${util.toTitleCase(table.displayName)} {\n`;
 
 	for (const field of table.fields) {
 		string += `${tab.repeat(3)}${field.name}\n`;
@@ -44,9 +48,11 @@ function buildAllQuery (table) {
 }
 
 function buildQueryById (table, idField) {
-	let query = `const query${util.toTitleCase(table.name)}ById = gql\`\n`;
-	query += `${tab}query($${table.name}: ${idField.type}!) {\n`;
-	query += `${tab.repeat(2)}${table.name}(${idField.name}: $${table.name}) {\n`;
+	let query = `const query${util.toTitleCase(table.displayName)}ById = gql\`\n`;
+	query += `${tab}query($${table.displayName}: ${idField.type}!) {\n`;
+	query += `${tab.repeat(2)}${table.displayName}(${idField.name}: $${
+		table.displayName
+	}) {\n`;
 
 	for (const field of table.fields) {
 		query += `${tab.repeat(3)}${field.name}\n`;

--- a/src/server/Generators/classes/typeBuilder.js
+++ b/src/server/Generators/classes/typeBuilder.js
@@ -26,9 +26,9 @@ class TypeBuilder {
 		let subQuery = "";
 
 		let typeQuery = `const ${
-			table.name
+			table.displayName
 		}Type = new GraphQLObjectType({\n${tab}name: '${
-			table.name
+			table.displayName
 		}',\n${tab}fields: () => ({`;
 
 		let firstLoop = true;
@@ -61,11 +61,14 @@ class TypeBuilder {
 		const subqueries = [];
 
 		for (const relatedTableIndex in column.relation) {
+			// TODO create table collection and move logic for lookup there
 			let subQuery = "";
 
 			const relatedTableLookup = relatedTableIndex.split(".");
 
-			const relatedTableName = processedMetadata[relatedTableLookup[0]].name;
+			const { displayName: rtDisplayName, name: rtName } = processedMetadata[
+				relatedTableLookup[0]
+			];
 
 			const relatedFieldName =
         processedMetadata[relatedTableLookup[0]].fields[relatedTableLookup[1]]
@@ -76,18 +79,18 @@ class TypeBuilder {
 
 			subQuery += `\n${tab.repeat(2)}${createSubQueryName(
 				relatedTableRelationType,
-				relatedTableName
+				rtDisplayName
 			)}: {\n${tab.repeat(3)}type: `;
 
 			if (relatedTableRelationType === "one to many") {
-				subQuery += `new GraphQLList(${relatedTableName}Type),`;
+				subQuery += `new GraphQLList(${rtDisplayName}Type),`;
 			} else {
-				subQuery += `${relatedTableName}Type,`;
+				subQuery += `${rtDisplayName}Type,`;
 			}
 			subQuery += `\n${tab.repeat(3)}resolve(parent, args) {\n${tab.repeat(4)}`;
 
 			subQuery += this.provider.selectWithWhere(
-				relatedTableName,
+				rtName,
 				relatedFieldName,
 				`parent.${column.name}`,
 				relatedTableRelationType === "one to many"
@@ -121,9 +124,9 @@ class TypeBuilder {
 
 	createFindAllRootQuery (table) {
 		let rootQuery = `${tab.repeat(2)}every${util.toTitleCase(
-			table.name
+			table.displayName
 		)}: {\n${tab.repeat(3)}type: new GraphQLList(${
-			table.name
+			table.displayName
 		}Type),\n${tab.repeat(3)}resolve() {\n${tab.repeat(4)}`;
 
 		rootQuery += this.provider.select(table.name);
@@ -134,8 +137,8 @@ class TypeBuilder {
 	createFindByIdQuery (table, idColumn) {
 		let rootQuery = `,\n${tab.repeat(
 			2
-		)}${table.name.toLowerCase()}: {\n${tab.repeat(3)}type: ${
-			table.name
+		)}${table.displayName.toLowerCase()}: {\n${tab.repeat(3)}type: ${
+			table.displayName
 		}Type,\n${tab.repeat(3)}args: {\n${tab.repeat(4)}${
 			idColumn.name
 		}: { type: ${tableDataTypeToGraphqlType(idColumn.type)} }\n${tab.repeat(
@@ -166,8 +169,10 @@ class TypeBuilder {
 
 	addMutation (table) {
 		let mutationQuery = `${tab.repeat(2)}add${util.toTitleCase(
-			table.name
-		)}: {\n${tab.repeat(3)}type: ${table.name}Type,\n${tab.repeat(3)}args: {\n`;
+			table.displayName
+		)}: {\n${tab.repeat(3)}type: ${table.displayName}Type,\n${tab.repeat(
+			3
+		)}args: {\n`;
 
 		let fieldNames = "";
 		let argNames = "";
@@ -211,8 +216,10 @@ class TypeBuilder {
 		}
 
 		let mutationQuery = `${tab.repeat(2)}update${util.toTitleCase(
-			table.name
-		)}: {\n${tab.repeat(3)}type: ${table.name}Type,\n${tab.repeat(3)}args: {\n`;
+			table.displayName
+		)}: {\n${tab.repeat(3)}type: ${table.displayName}Type,\n${tab.repeat(
+			3
+		)}args: {\n`;
 
 		let firstLoop = true;
 		for (const field of table.fields) {
@@ -251,8 +258,8 @@ class TypeBuilder {
 		}
 
 		let mutationQuery = `${tab.repeat(2)}delete${util.toTitleCase(
-			table.name
-		)}: {\n${tab.repeat(3)}type: ${table.name}Type,\n${tab.repeat(
+			table.displayName
+		)}: {\n${tab.repeat(3)}type: ${table.displayName}Type,\n${tab.repeat(
 			3
 		)}args: {\n${tab.repeat(4)}${
 			idColumn.name


### PR DESCRIPTION

SWQL-30, SWQL-31 | fixed issue where spaces in table names caused build to break
                     - Added square brackets around table names in mssql provider
                     - added field to processedTable for original table name
                     - updated code generation code to use correct versions of name (display name for functions and graph ql and name for sql queries)
                     - tested with both mssql and pgsql