### PR TITLE
SWQL-76 SWQL-77 SWQL-78 | Fixed metadata bug, bigint and binary data types

### DIFF
--- a/src/DBMetadata/columnTypeTranslators.ts
+++ b/src/DBMetadata/columnTypeTranslators.ts
@@ -1,4 +1,4 @@
-export function pgSQL (type: string) {
+export function pgSQL(type: string) {
     switch (type) {
         case 'integer':
             return 'Integer';
@@ -24,9 +24,8 @@ export function pgSQL (type: string) {
     }
 }
 
-export function msSQL (type: string) {
+export function msSQL(type: string) {
     switch (type) {
-        case 'bigint':
         case 'bit':
         case 'int':
         case 'smallint':
@@ -38,6 +37,7 @@ export function msSQL (type: string) {
         case 'smallmoney':
         case 'float':
         case 'real':
+        case 'bigint':
             return 'Float';
 
         case 'date':

--- a/src/DBMetadata/columnTypeTranslators.ts
+++ b/src/DBMetadata/columnTypeTranslators.ts
@@ -58,10 +58,12 @@ export function msSQL(type: string) {
         case 'nchar':
         case 'nvarchar':
         case 'ntext':
-        case 'binary':
-        case 'image':
-        case 'varbinary':
             return 'String';
+
+        case 'binary':
+        case 'varbinary':
+        case 'image':
+            return 'IntegerList'
 
         default:
             throw new Error(`Unsupported column type found: ${type}`);

--- a/src/DBMetadata/metadataRetriever.ts
+++ b/src/DBMetadata/metadataRetriever.ts
@@ -2,7 +2,7 @@ import DBMetadata from '../models/dbMetadata';
 import ConnData from '../models/connData';
 
 interface IMetadataRetriever {
-    getSchemaInfo(connString: string, schema: string): Promise<DBMetadata[]>;
+    getSchemaInfo(connString: string, schema?: string): Promise<DBMetadata[]>;
     buildConnectionString(info: ConnData): string;
 }
 

--- a/src/Generators/provider/dbProvider.ts
+++ b/src/Generators/provider/dbProvider.ts
@@ -1,3 +1,5 @@
+import ProcessedField from "../../models/processedField";
+
 interface IDBProvider {
     connection(): void;
     selectWithWhere(table: string, col: string, val: string, returnsMany: boolean): void;
@@ -5,7 +7,7 @@ interface IDBProvider {
     insert(table: string, cols: string, args: string): void;
     update(table: string, idColumnName: string): void;
     delete(table: string, column: string): void;
-    parameterize(): void;
+    parameterize(fields: ProcessedField[]): void;
     configureExport(): void;
 }
 

--- a/src/Generators/provider/pgSqlProvider.ts
+++ b/src/Generators/provider/pgSqlProvider.ts
@@ -1,13 +1,14 @@
 import IDBProvider from './dbProvider';
+import ProcessedField from '../../models/processedField';
 
 /* eslint-disable no-useless-escape */
 /* eslint-disable no-unused-expressions */
 const tab = `  `;
 
 class PgSqlProvider implements IDBProvider {
-    constructor (private connString: string) {}
+    constructor(private connString: string) { }
 
-    connection () {
+    connection() {
         let conn = `const pgp = require('pg-promise')();\n`;
         conn += `const connect = {};\n`;
         conn += `// WARNING - Properly secure the connection string\n`;
@@ -16,7 +17,7 @@ class PgSqlProvider implements IDBProvider {
         return conn;
     }
 
-    selectWithWhere (table: string, col: string, val: string, returnsMany: boolean) {
+    selectWithWhere(table: string, col: string, val: string, returnsMany: boolean) {
         let query = `const sql = 'SELECT * FROM "${table}" WHERE "${col}" = $1';\n`;
 
         returnsMany ?
@@ -28,7 +29,7 @@ class PgSqlProvider implements IDBProvider {
         return query;
     }
 
-    select (table: string) {
+    select(table: string) {
         let query = `const sql = 'SELECT * FROM "${table}"';\n`;
         query += `${tab.repeat(4)}return connect.conn.many(sql)\n`;
 
@@ -37,7 +38,7 @@ class PgSqlProvider implements IDBProvider {
         return query;
     }
 
-    insert (table: string, cols: string, args: string) {
+    insert(table: string, cols: string, args: string) {
         const normalized = args
             .split(',')
             .map(a => a.replace(/[' | { | } | \$]/g, ''));
@@ -54,7 +55,7 @@ class PgSqlProvider implements IDBProvider {
         return query;
     }
 
-    update (table: string, idColumnName: string) {
+    update(table: string, idColumnName: string) {
         let query = `const sql = \`UPDATE "${table}" SET \${parameterized} WHERE "${idColumnName}" = $1 RETURNING *\`;\n`;
         query += `${tab.repeat(
             4
@@ -64,7 +65,7 @@ class PgSqlProvider implements IDBProvider {
         return query;
     }
 
-    delete (table: string, column: string) {
+    delete(table: string, column: string) {
         let query = `const sql = 'DELETE FROM "${table}" WHERE "${column}" = $1 RETURNING *';\n`;
         query += `${tab.repeat(4)}return connect.conn.one(sql, args.${column})\n`;
 
@@ -73,7 +74,7 @@ class PgSqlProvider implements IDBProvider {
         return query;
     }
 
-    parameterize () {
+    parameterize(fields: ProcessedField[]) {
         let query = `${tab.repeat(4)}let updateValues = [];\n`;
         query += `${tab.repeat(4)}let idx = 2;\n\n`;
 
@@ -88,7 +89,7 @@ class PgSqlProvider implements IDBProvider {
         return query;
     }
 
-    configureExport () {
+    configureExport() {
         return `module.exports = new GraphQLSchema({\n${tab}query: RootQuery,\n${tab}mutation: Mutation\n});`;
     }
 }

--- a/src/__tests__/__snapshots__/graphQLGenerator.test.ts.snap
+++ b/src/__tests__/__snapshots__/graphQLGenerator.test.ts.snap
@@ -464,6 +464,1027 @@ export {
 };"
 `;
 
+exports[`Type generation tests Should load binary data into a buffer for insert mutations 1`] = `
+"const graphql = require('graphql');
+const graphql_iso_date = require('graphql-iso-date');
+const pgp = require('pg-promise')();
+const connect = {};
+// WARNING - Properly secure the connection string
+connect.conn = pgp('postgres://test@test.com:5432/test');
+
+const { 
+	  GraphQLObjectType,
+	  GraphQLSchema,
+	  GraphQLID,
+	  GraphQLString, 
+	  GraphQLInt, 
+	  GraphQLBoolean,
+	  GraphQLList,
+	  GraphQLFloat,
+	  GraphQLNonNull
+	} = graphql;
+	  
+const { 
+	  GraphQLDate,
+	  GraphQLTime,
+	  GraphQLDateTime
+	} = graphql_iso_date;
+	  
+const authorType = new GraphQLObjectType({
+  name: 'author',
+  fields: () => ({
+    id: { type: GraphQLID },
+    name: { type: GraphQLString },
+    binaryCol: { type: new GraphQLList(GraphQLInt) },
+    everyRelatedBooks: {
+      type: new GraphQLList(booksType),
+      resolve(parent, args) {
+        const sql = 'SELECT * FROM \\"books\\" WHERE \\"author_id\\" = $1';
+        return connect.conn.many(sql, parent.id)
+          .then(data => {
+            return data;
+          })
+          .catch(err => {
+            return ('The error is', err);
+          })
+      }
+    }
+  })
+});
+
+const book_orderType = new GraphQLObjectType({
+  name: 'book_order',
+  fields: () => ({
+    id: { type: GraphQLID },
+    book_id: { type: GraphQLID },
+    order_id: { type: GraphQLID },
+    relatedBooks: {
+      type: booksType,
+      resolve(parent, args) {
+        const sql = 'SELECT * FROM \\"books\\" WHERE \\"id\\" = $1';
+        return connect.conn.one(sql, parent.book_id)
+          .then(data => {
+            return data;
+          })
+          .catch(err => {
+            return ('The error is', err);
+          })
+      }
+    }, 
+    relatedOrder: {
+      type: orderType,
+      resolve(parent, args) {
+        const sql = 'SELECT * FROM \\"order\\" WHERE \\"id\\" = $1';
+        return connect.conn.one(sql, parent.order_id)
+          .then(data => {
+            return data;
+          })
+          .catch(err => {
+            return ('The error is', err);
+          })
+      }
+    }
+  })
+});
+
+const booksType = new GraphQLObjectType({
+  name: 'books',
+  fields: () => ({
+    genre_id: { type: GraphQLID },
+    id: { type: GraphQLID },
+    test: { type: GraphQLFloat },
+    name: { type: GraphQLString },
+    publish_date: { type: GraphQLDate },
+    author_id: { type: GraphQLID },
+    relatedGenre: {
+      type: genreType,
+      resolve(parent, args) {
+        const sql = 'SELECT * FROM \\"genre\\" WHERE \\"id\\" = $1';
+        return connect.conn.one(sql, parent.genre_id)
+          .then(data => {
+            return data;
+          })
+          .catch(err => {
+            return ('The error is', err);
+          })
+      }
+    }, 
+    everyRelatedBook_order: {
+      type: new GraphQLList(book_orderType),
+      resolve(parent, args) {
+        const sql = 'SELECT * FROM \\"book_order\\" WHERE \\"book_id\\" = $1';
+        return connect.conn.many(sql, parent.id)
+          .then(data => {
+            return data;
+          })
+          .catch(err => {
+            return ('The error is', err);
+          })
+      }
+    }, 
+    relatedAuthor: {
+      type: authorType,
+      resolve(parent, args) {
+        const sql = 'SELECT * FROM \\"author\\" WHERE \\"id\\" = $1';
+        return connect.conn.one(sql, parent.author_id)
+          .then(data => {
+            return data;
+          })
+          .catch(err => {
+            return ('The error is', err);
+          })
+      }
+    }
+  })
+});
+
+const genreType = new GraphQLObjectType({
+  name: 'genre',
+  fields: () => ({
+    id: { type: GraphQLID },
+    name: { type: GraphQLString },
+    everyRelatedBooks: {
+      type: new GraphQLList(booksType),
+      resolve(parent, args) {
+        const sql = 'SELECT * FROM \\"books\\" WHERE \\"genre_id\\" = $1';
+        return connect.conn.many(sql, parent.id)
+          .then(data => {
+            return data;
+          })
+          .catch(err => {
+            return ('The error is', err);
+          })
+      }
+    }
+  })
+});
+
+const orderType = new GraphQLObjectType({
+  name: 'order',
+  fields: () => ({
+    id: { type: GraphQLID },
+    created_at: { type: GraphQLDate },
+    user_id: { type: GraphQLID },
+    status_id: { type: GraphQLID },
+    shipping_id: { type: GraphQLID },
+    everyRelatedBook_order: {
+      type: new GraphQLList(book_orderType),
+      resolve(parent, args) {
+        const sql = 'SELECT * FROM \\"book_order\\" WHERE \\"order_id\\" = $1';
+        return connect.conn.many(sql, parent.id)
+          .then(data => {
+            return data;
+          })
+          .catch(err => {
+            return ('The error is', err);
+          })
+      }
+    }, 
+    relatedUser: {
+      type: userType,
+      resolve(parent, args) {
+        const sql = 'SELECT * FROM \\"user\\" WHERE \\"id\\" = $1';
+        return connect.conn.one(sql, parent.user_id)
+          .then(data => {
+            return data;
+          })
+          .catch(err => {
+            return ('The error is', err);
+          })
+      }
+    }, 
+    relatedStatus: {
+      type: statusType,
+      resolve(parent, args) {
+        const sql = 'SELECT * FROM \\"status\\" WHERE \\"id\\" = $1';
+        return connect.conn.one(sql, parent.status_id)
+          .then(data => {
+            return data;
+          })
+          .catch(err => {
+            return ('The error is', err);
+          })
+      }
+    }, 
+    relatedShipping_method: {
+      type: shipping_methodType,
+      resolve(parent, args) {
+        const sql = 'SELECT * FROM \\"shipping_method\\" WHERE \\"id\\" = $1';
+        return connect.conn.one(sql, parent.shipping_id)
+          .then(data => {
+            return data;
+          })
+          .catch(err => {
+            return ('The error is', err);
+          })
+      }
+    }
+  })
+});
+
+const shipping_methodType = new GraphQLObjectType({
+  name: 'shipping_method',
+  fields: () => ({
+    id: { type: GraphQLID },
+    method: { type: GraphQLString },
+    everyRelatedOrder: {
+      type: new GraphQLList(orderType),
+      resolve(parent, args) {
+        const sql = 'SELECT * FROM \\"order\\" WHERE \\"shipping_id\\" = $1';
+        return connect.conn.many(sql, parent.id)
+          .then(data => {
+            return data;
+          })
+          .catch(err => {
+            return ('The error is', err);
+          })
+      }
+    }
+  })
+});
+
+const statusType = new GraphQLObjectType({
+  name: 'status',
+  fields: () => ({
+    id: { type: GraphQLID },
+    code: { type: GraphQLString },
+    everyRelatedOrder: {
+      type: new GraphQLList(orderType),
+      resolve(parent, args) {
+        const sql = 'SELECT * FROM \\"order\\" WHERE \\"status_id\\" = $1';
+        return connect.conn.many(sql, parent.id)
+          .then(data => {
+            return data;
+          })
+          .catch(err => {
+            return ('The error is', err);
+          })
+      }
+    }
+  })
+});
+
+const userType = new GraphQLObjectType({
+  name: 'user',
+  fields: () => ({
+    id: { type: GraphQLID },
+    phone_number: { type: GraphQLString },
+    address: { type: GraphQLString },
+    name: { type: GraphQLString },
+    everyRelatedOrder: {
+      type: new GraphQLList(orderType),
+      resolve(parent, args) {
+        const sql = 'SELECT * FROM \\"order\\" WHERE \\"user_id\\" = $1';
+        return connect.conn.many(sql, parent.id)
+          .then(data => {
+            return data;
+          })
+          .catch(err => {
+            return ('The error is', err);
+          })
+      }
+    }
+  })
+});
+
+const RootQuery = new GraphQLObjectType({
+  name: 'RootQueryType',
+  fields: {
+    everyAuthor: {
+      type: new GraphQLList(authorType),
+      resolve() {
+        const sql = 'SELECT * FROM \\"author\\"';
+        return connect.conn.many(sql)
+          .then(data => {
+            return data;
+          })
+          .catch(err => {
+            return ('The error is', err);
+          })
+      }
+    },
+    author: {
+      type: authorType,
+      args: {
+        id: { type: GraphQLID }
+      },
+      resolve(parent, args) {
+        const sql = 'SELECT * FROM \\"author\\" WHERE \\"id\\" = $1';
+        return connect.conn.one(sql, args.id)
+          .then(data => {
+            return data;
+          })
+          .catch(err => {
+            return ('The error is', err);
+          })
+      }
+    },
+    everyBook_order: {
+      type: new GraphQLList(book_orderType),
+      resolve() {
+        const sql = 'SELECT * FROM \\"book_order\\"';
+        return connect.conn.many(sql)
+          .then(data => {
+            return data;
+          })
+          .catch(err => {
+            return ('The error is', err);
+          })
+      }
+    },
+    book_order: {
+      type: book_orderType,
+      args: {
+        id: { type: GraphQLID }
+      },
+      resolve(parent, args) {
+        const sql = 'SELECT * FROM \\"book_order\\" WHERE \\"id\\" = $1';
+        return connect.conn.one(sql, args.id)
+          .then(data => {
+            return data;
+          })
+          .catch(err => {
+            return ('The error is', err);
+          })
+      }
+    },
+    everyBooks: {
+      type: new GraphQLList(booksType),
+      resolve() {
+        const sql = 'SELECT * FROM \\"books\\"';
+        return connect.conn.many(sql)
+          .then(data => {
+            return data;
+          })
+          .catch(err => {
+            return ('The error is', err);
+          })
+      }
+    },
+    books: {
+      type: booksType,
+      args: {
+        id: { type: GraphQLID }
+      },
+      resolve(parent, args) {
+        const sql = 'SELECT * FROM \\"books\\" WHERE \\"id\\" = $1';
+        return connect.conn.one(sql, args.id)
+          .then(data => {
+            return data;
+          })
+          .catch(err => {
+            return ('The error is', err);
+          })
+      }
+    },
+    everyGenre: {
+      type: new GraphQLList(genreType),
+      resolve() {
+        const sql = 'SELECT * FROM \\"genre\\"';
+        return connect.conn.many(sql)
+          .then(data => {
+            return data;
+          })
+          .catch(err => {
+            return ('The error is', err);
+          })
+      }
+    },
+    genre: {
+      type: genreType,
+      args: {
+        id: { type: GraphQLID }
+      },
+      resolve(parent, args) {
+        const sql = 'SELECT * FROM \\"genre\\" WHERE \\"id\\" = $1';
+        return connect.conn.one(sql, args.id)
+          .then(data => {
+            return data;
+          })
+          .catch(err => {
+            return ('The error is', err);
+          })
+      }
+    },
+    everyOrder: {
+      type: new GraphQLList(orderType),
+      resolve() {
+        const sql = 'SELECT * FROM \\"order\\"';
+        return connect.conn.many(sql)
+          .then(data => {
+            return data;
+          })
+          .catch(err => {
+            return ('The error is', err);
+          })
+      }
+    },
+    order: {
+      type: orderType,
+      args: {
+        id: { type: GraphQLID }
+      },
+      resolve(parent, args) {
+        const sql = 'SELECT * FROM \\"order\\" WHERE \\"id\\" = $1';
+        return connect.conn.one(sql, args.id)
+          .then(data => {
+            return data;
+          })
+          .catch(err => {
+            return ('The error is', err);
+          })
+      }
+    },
+    everyShipping_method: {
+      type: new GraphQLList(shipping_methodType),
+      resolve() {
+        const sql = 'SELECT * FROM \\"shipping_method\\"';
+        return connect.conn.many(sql)
+          .then(data => {
+            return data;
+          })
+          .catch(err => {
+            return ('The error is', err);
+          })
+      }
+    },
+    shipping_method: {
+      type: shipping_methodType,
+      args: {
+        id: { type: GraphQLID }
+      },
+      resolve(parent, args) {
+        const sql = 'SELECT * FROM \\"shipping_method\\" WHERE \\"id\\" = $1';
+        return connect.conn.one(sql, args.id)
+          .then(data => {
+            return data;
+          })
+          .catch(err => {
+            return ('The error is', err);
+          })
+      }
+    },
+    everyStatus: {
+      type: new GraphQLList(statusType),
+      resolve() {
+        const sql = 'SELECT * FROM \\"status\\"';
+        return connect.conn.many(sql)
+          .then(data => {
+            return data;
+          })
+          .catch(err => {
+            return ('The error is', err);
+          })
+      }
+    },
+    status: {
+      type: statusType,
+      args: {
+        id: { type: GraphQLID }
+      },
+      resolve(parent, args) {
+        const sql = 'SELECT * FROM \\"status\\" WHERE \\"id\\" = $1';
+        return connect.conn.one(sql, args.id)
+          .then(data => {
+            return data;
+          })
+          .catch(err => {
+            return ('The error is', err);
+          })
+      }
+    },
+    everyUser: {
+      type: new GraphQLList(userType),
+      resolve() {
+        const sql = 'SELECT * FROM \\"user\\"';
+        return connect.conn.many(sql)
+          .then(data => {
+            return data;
+          })
+          .catch(err => {
+            return ('The error is', err);
+          })
+      }
+    },
+    user: {
+      type: userType,
+      args: {
+        id: { type: GraphQLID }
+      },
+      resolve(parent, args) {
+        const sql = 'SELECT * FROM \\"user\\" WHERE \\"id\\" = $1';
+        return connect.conn.one(sql, args.id)
+          .then(data => {
+            return data;
+          })
+          .catch(err => {
+            return ('The error is', err);
+          })
+      }
+    }
+  }
+});
+
+const Mutation = new GraphQLObjectType({
+  name: 'Mutation',
+  fields: {
+    addAuthor: {
+      type: authorType,
+      args: {
+        name: { type: GraphQLString },
+        binaryCol: { type: new GraphQLNonNull(new GraphQLList(GraphQLInt)) }
+      },
+      resolve(parent, args) {
+                args.binaryCol ? args.binaryCol = Buffer.from(args.binaryCol) : undefined 
+const sql = 'INSERT INTO \\"author\\" (name, binaryCol) VALUES ($1, $2) RETURNING *';
+        return connect.conn.one(sql, [args.name, args.binaryCol])
+          .then(data => {
+            return data;
+          })
+          .catch(err => {
+            return ('The error is', err);
+          })
+      }
+    },
+    updateAuthor: {
+      type: authorType,
+      args: {
+        id: { type: new GraphQLNonNull(GraphQLID) },
+        name: { type: GraphQLString },
+        binaryCol: { type: new GraphQLNonNull(new GraphQLList(GraphQLInt)) }
+      },
+      resolve(parent, args) {
+        const { id, ...rest } = args;
+        args.binaryCol ? args.binaryCol = Buffer.from(args.binaryCol) : undefined 
+        let updateValues = [];
+        let idx = 2;
+
+        for (const prop in rest) {
+            updateValues.push(\`\${prop} = $\${idx}\`);
+            idx++;
+        }
+        const parameterized = updateValues.join(\\", \\");
+        const sql = \`UPDATE \\"author\\" SET \${parameterized} WHERE \\"id\\" = $1 RETURNING *\`;
+        return connect.conn.one(sql, [id, ...Object.values(rest)])
+          .then(data => {
+            return data;
+          })
+          .catch(err => {
+            return ('The error is', err);
+          })
+      }
+    },
+    deleteAuthor: {
+      type: authorType,
+      args: {
+        id: { type: GraphQLID }
+      },
+      resolve(parent, args) {
+        const sql = 'DELETE FROM \\"author\\" WHERE \\"id\\" = $1 RETURNING *';
+        return connect.conn.one(sql, args.id)
+          .then(data => {
+            return data;
+          })
+          .catch(err => {
+            return ('The error is', err);
+          })
+      }
+    },
+    addBook_order: {
+      type: book_orderType,
+      args: {
+        book_id: { type: GraphQLID },
+        order_id: { type: GraphQLID }
+      },
+      resolve(parent, args) {
+        const sql = 'INSERT INTO \\"book_order\\" (book_id, order_id) VALUES ($1, $2) RETURNING *';
+        return connect.conn.one(sql, [args.book_id, args.order_id])
+          .then(data => {
+            return data;
+          })
+          .catch(err => {
+            return ('The error is', err);
+          })
+      }
+    },
+    updateBook_order: {
+      type: book_orderType,
+      args: {
+        id: { type: new GraphQLNonNull(GraphQLID) },
+        book_id: { type: GraphQLID },
+        order_id: { type: GraphQLID }
+      },
+      resolve(parent, args) {
+        const { id, ...rest } = args;
+        let updateValues = [];
+        let idx = 2;
+
+        for (const prop in rest) {
+            updateValues.push(\`\${prop} = $\${idx}\`);
+            idx++;
+        }
+        const parameterized = updateValues.join(\\", \\");
+        const sql = \`UPDATE \\"book_order\\" SET \${parameterized} WHERE \\"id\\" = $1 RETURNING *\`;
+        return connect.conn.one(sql, [id, ...Object.values(rest)])
+          .then(data => {
+            return data;
+          })
+          .catch(err => {
+            return ('The error is', err);
+          })
+      }
+    },
+    deleteBook_order: {
+      type: book_orderType,
+      args: {
+        id: { type: GraphQLID }
+      },
+      resolve(parent, args) {
+        const sql = 'DELETE FROM \\"book_order\\" WHERE \\"id\\" = $1 RETURNING *';
+        return connect.conn.one(sql, args.id)
+          .then(data => {
+            return data;
+          })
+          .catch(err => {
+            return ('The error is', err);
+          })
+      }
+    },
+    addBooks: {
+      type: booksType,
+      args: {
+        genre_id: { type: GraphQLID },
+        test: { type: GraphQLFloat },
+        name: { type: GraphQLString },
+        publish_date: { type: GraphQLDate },
+        author_id: { type: GraphQLID }
+      },
+      resolve(parent, args) {
+        const sql = 'INSERT INTO \\"books\\" (genre_id, test, name, publish_date, author_id) VALUES ($1, $2, $3, $4, $5) RETURNING *';
+        return connect.conn.one(sql, [args.genre_id, args.test, args.name, args.publish_date, args.author_id])
+          .then(data => {
+            return data;
+          })
+          .catch(err => {
+            return ('The error is', err);
+          })
+      }
+    },
+    updateBooks: {
+      type: booksType,
+      args: {
+        genre_id: { type: GraphQLID },
+        id: { type: new GraphQLNonNull(GraphQLID) },
+        test: { type: GraphQLFloat },
+        name: { type: GraphQLString },
+        publish_date: { type: GraphQLDate },
+        author_id: { type: GraphQLID }
+      },
+      resolve(parent, args) {
+        const { id, ...rest } = args;
+        let updateValues = [];
+        let idx = 2;
+
+        for (const prop in rest) {
+            updateValues.push(\`\${prop} = $\${idx}\`);
+            idx++;
+        }
+        const parameterized = updateValues.join(\\", \\");
+        const sql = \`UPDATE \\"books\\" SET \${parameterized} WHERE \\"id\\" = $1 RETURNING *\`;
+        return connect.conn.one(sql, [id, ...Object.values(rest)])
+          .then(data => {
+            return data;
+          })
+          .catch(err => {
+            return ('The error is', err);
+          })
+      }
+    },
+    deleteBooks: {
+      type: booksType,
+      args: {
+        id: { type: GraphQLID }
+      },
+      resolve(parent, args) {
+        const sql = 'DELETE FROM \\"books\\" WHERE \\"id\\" = $1 RETURNING *';
+        return connect.conn.one(sql, args.id)
+          .then(data => {
+            return data;
+          })
+          .catch(err => {
+            return ('The error is', err);
+          })
+      }
+    },
+    addGenre: {
+      type: genreType,
+      args: {
+        name: { type: GraphQLString }
+      },
+      resolve(parent, args) {
+        const sql = 'INSERT INTO \\"genre\\" (name) VALUES ($1) RETURNING *';
+        return connect.conn.one(sql, [args.name])
+          .then(data => {
+            return data;
+          })
+          .catch(err => {
+            return ('The error is', err);
+          })
+      }
+    },
+    updateGenre: {
+      type: genreType,
+      args: {
+        id: { type: new GraphQLNonNull(GraphQLID) },
+        name: { type: GraphQLString }
+      },
+      resolve(parent, args) {
+        const { id, ...rest } = args;
+        let updateValues = [];
+        let idx = 2;
+
+        for (const prop in rest) {
+            updateValues.push(\`\${prop} = $\${idx}\`);
+            idx++;
+        }
+        const parameterized = updateValues.join(\\", \\");
+        const sql = \`UPDATE \\"genre\\" SET \${parameterized} WHERE \\"id\\" = $1 RETURNING *\`;
+        return connect.conn.one(sql, [id, ...Object.values(rest)])
+          .then(data => {
+            return data;
+          })
+          .catch(err => {
+            return ('The error is', err);
+          })
+      }
+    },
+    deleteGenre: {
+      type: genreType,
+      args: {
+        id: { type: GraphQLID }
+      },
+      resolve(parent, args) {
+        const sql = 'DELETE FROM \\"genre\\" WHERE \\"id\\" = $1 RETURNING *';
+        return connect.conn.one(sql, args.id)
+          .then(data => {
+            return data;
+          })
+          .catch(err => {
+            return ('The error is', err);
+          })
+      }
+    },
+    addOrder: {
+      type: orderType,
+      args: {
+        created_at: { type: GraphQLDate },
+        user_id: { type: GraphQLID },
+        status_id: { type: GraphQLID },
+        shipping_id: { type: GraphQLID }
+      },
+      resolve(parent, args) {
+        const sql = 'INSERT INTO \\"order\\" (created_at, user_id, status_id, shipping_id) VALUES ($1, $2, $3, $4) RETURNING *';
+        return connect.conn.one(sql, [args.created_at, args.user_id, args.status_id, args.shipping_id])
+          .then(data => {
+            return data;
+          })
+          .catch(err => {
+            return ('The error is', err);
+          })
+      }
+    },
+    updateOrder: {
+      type: orderType,
+      args: {
+        id: { type: new GraphQLNonNull(GraphQLID) },
+        created_at: { type: GraphQLDate },
+        user_id: { type: GraphQLID },
+        status_id: { type: GraphQLID },
+        shipping_id: { type: GraphQLID }
+      },
+      resolve(parent, args) {
+        const { id, ...rest } = args;
+        let updateValues = [];
+        let idx = 2;
+
+        for (const prop in rest) {
+            updateValues.push(\`\${prop} = $\${idx}\`);
+            idx++;
+        }
+        const parameterized = updateValues.join(\\", \\");
+        const sql = \`UPDATE \\"order\\" SET \${parameterized} WHERE \\"id\\" = $1 RETURNING *\`;
+        return connect.conn.one(sql, [id, ...Object.values(rest)])
+          .then(data => {
+            return data;
+          })
+          .catch(err => {
+            return ('The error is', err);
+          })
+      }
+    },
+    deleteOrder: {
+      type: orderType,
+      args: {
+        id: { type: GraphQLID }
+      },
+      resolve(parent, args) {
+        const sql = 'DELETE FROM \\"order\\" WHERE \\"id\\" = $1 RETURNING *';
+        return connect.conn.one(sql, args.id)
+          .then(data => {
+            return data;
+          })
+          .catch(err => {
+            return ('The error is', err);
+          })
+      }
+    },
+    addShipping_method: {
+      type: shipping_methodType,
+      args: {
+        method: { type: GraphQLString }
+      },
+      resolve(parent, args) {
+        const sql = 'INSERT INTO \\"shipping_method\\" (method) VALUES ($1) RETURNING *';
+        return connect.conn.one(sql, [args.method])
+          .then(data => {
+            return data;
+          })
+          .catch(err => {
+            return ('The error is', err);
+          })
+      }
+    },
+    updateShipping_method: {
+      type: shipping_methodType,
+      args: {
+        id: { type: new GraphQLNonNull(GraphQLID) },
+        method: { type: GraphQLString }
+      },
+      resolve(parent, args) {
+        const { id, ...rest } = args;
+        let updateValues = [];
+        let idx = 2;
+
+        for (const prop in rest) {
+            updateValues.push(\`\${prop} = $\${idx}\`);
+            idx++;
+        }
+        const parameterized = updateValues.join(\\", \\");
+        const sql = \`UPDATE \\"shipping_method\\" SET \${parameterized} WHERE \\"id\\" = $1 RETURNING *\`;
+        return connect.conn.one(sql, [id, ...Object.values(rest)])
+          .then(data => {
+            return data;
+          })
+          .catch(err => {
+            return ('The error is', err);
+          })
+      }
+    },
+    deleteShipping_method: {
+      type: shipping_methodType,
+      args: {
+        id: { type: GraphQLID }
+      },
+      resolve(parent, args) {
+        const sql = 'DELETE FROM \\"shipping_method\\" WHERE \\"id\\" = $1 RETURNING *';
+        return connect.conn.one(sql, args.id)
+          .then(data => {
+            return data;
+          })
+          .catch(err => {
+            return ('The error is', err);
+          })
+      }
+    },
+    addStatus: {
+      type: statusType,
+      args: {
+        code: { type: GraphQLString }
+      },
+      resolve(parent, args) {
+        const sql = 'INSERT INTO \\"status\\" (code) VALUES ($1) RETURNING *';
+        return connect.conn.one(sql, [args.code])
+          .then(data => {
+            return data;
+          })
+          .catch(err => {
+            return ('The error is', err);
+          })
+      }
+    },
+    updateStatus: {
+      type: statusType,
+      args: {
+        id: { type: new GraphQLNonNull(GraphQLID) },
+        code: { type: GraphQLString }
+      },
+      resolve(parent, args) {
+        const { id, ...rest } = args;
+        let updateValues = [];
+        let idx = 2;
+
+        for (const prop in rest) {
+            updateValues.push(\`\${prop} = $\${idx}\`);
+            idx++;
+        }
+        const parameterized = updateValues.join(\\", \\");
+        const sql = \`UPDATE \\"status\\" SET \${parameterized} WHERE \\"id\\" = $1 RETURNING *\`;
+        return connect.conn.one(sql, [id, ...Object.values(rest)])
+          .then(data => {
+            return data;
+          })
+          .catch(err => {
+            return ('The error is', err);
+          })
+      }
+    },
+    deleteStatus: {
+      type: statusType,
+      args: {
+        id: { type: GraphQLID }
+      },
+      resolve(parent, args) {
+        const sql = 'DELETE FROM \\"status\\" WHERE \\"id\\" = $1 RETURNING *';
+        return connect.conn.one(sql, args.id)
+          .then(data => {
+            return data;
+          })
+          .catch(err => {
+            return ('The error is', err);
+          })
+      }
+    },
+    addUser: {
+      type: userType,
+      args: {
+        phone_number: { type: GraphQLString },
+        address: { type: GraphQLString },
+        name: { type: new GraphQLNonNull(GraphQLString) }
+      },
+      resolve(parent, args) {
+        const sql = 'INSERT INTO \\"user\\" (phone_number, address, name) VALUES ($1, $2, $3) RETURNING *';
+        return connect.conn.one(sql, [args.phone_number, args.address, args.name])
+          .then(data => {
+            return data;
+          })
+          .catch(err => {
+            return ('The error is', err);
+          })
+      }
+    },
+    updateUser: {
+      type: userType,
+      args: {
+        id: { type: new GraphQLNonNull(GraphQLID) },
+        phone_number: { type: GraphQLString },
+        address: { type: GraphQLString },
+        name: { type: new GraphQLNonNull(GraphQLString) }
+      },
+      resolve(parent, args) {
+        const { id, ...rest } = args;
+        let updateValues = [];
+        let idx = 2;
+
+        for (const prop in rest) {
+            updateValues.push(\`\${prop} = $\${idx}\`);
+            idx++;
+        }
+        const parameterized = updateValues.join(\\", \\");
+        const sql = \`UPDATE \\"user\\" SET \${parameterized} WHERE \\"id\\" = $1 RETURNING *\`;
+        return connect.conn.one(sql, [id, ...Object.values(rest)])
+          .then(data => {
+            return data;
+          })
+          .catch(err => {
+            return ('The error is', err);
+          })
+      }
+    },
+    deleteUser: {
+      type: userType,
+      args: {
+        id: { type: GraphQLID }
+      },
+      resolve(parent, args) {
+        const sql = 'DELETE FROM \\"user\\" WHERE \\"id\\" = $1 RETURNING *';
+        return connect.conn.one(sql, args.id)
+          .then(data => {
+            return data;
+          })
+          .catch(err => {
+            return ('The error is', err);
+          })
+      }
+    }
+  }
+});
+
+module.exports = new GraphQLSchema({
+  query: RootQuery,
+  mutation: Mutation
+});"
+`;
+
 exports[`Type generation tests Should match the snapshot 1`] = `
 "const graphql = require('graphql');
 const graphql_iso_date = require('graphql-iso-date');

--- a/src/__tests__/__snapshots__/msSqlProvider.test.ts.snap
+++ b/src/__tests__/__snapshots__/msSqlProvider.test.ts.snap
@@ -1,5 +1,18 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`MSSqlProvider Should correctly generate code to wrap binary data in a buffer 1`] = `
+"        let updateValues = [];
+        const req = pool.request();
+        for (const prop in rest) {
+            const data = ['binaryCol'].includes(prop) ? Buffer.from(rest[prop]) : rest[prop]
+            req.input(\`\${prop}\`, data);
+            updateValues.push(\`\${prop} = @\${prop}\`);
+        }
+
+        const parameterized = updateValues.join(\\", \\");
+"
+`;
+
 exports[`MSSqlProvider Should generate code for configureExport that matches the snapshot 1`] = `
 "module.exports = function(connection) { 
               pool = connection;
@@ -34,7 +47,8 @@ exports[`MSSqlProvider Should generate code for paramaterize that matches the sn
 "        let updateValues = [];
         const req = pool.request();
         for (const prop in rest) {
-            req.input(\`\${prop}\`, rest[prop]);
+            const data = rest[prop]
+            req.input(\`\${prop}\`, data);
             updateValues.push(\`\${prop} = @\${prop}\`);
         }
 

--- a/src/__tests__/graphQLGenerator.test.ts
+++ b/src/__tests__/graphQLGenerator.test.ts
@@ -48,4 +48,27 @@ describe('Type generation tests', () => {
 
         expect(output).toMatchSnapshot();
     });
+
+    it('Should load binary data into a buffer for insert mutations', () => {
+        const tables = input.tables;
+        tables[0].fields.push({
+            name: 'binaryCol',
+            type: 'IntegerList',
+            primaryKey: false,
+            unique: false,
+            required: true,
+            inRelationship: false,
+            relation: {
+            },
+            tableNum: 0,
+            fieldNum: 2,
+        })
+
+        const { types: output } = generateGraphQL(
+            input.tables as any,
+            new PgSqlProvider('postgres://test@test.com:5432/test')
+        );
+
+        expect(output).toMatchSnapshot();
+    })
 });

--- a/src/__tests__/msSqlProvider.test.ts
+++ b/src/__tests__/msSqlProvider.test.ts
@@ -1,6 +1,7 @@
 /* eslint-disable no-undef */
 import MSSqlProvider from '../Generators/provider/msSqlProvider';
 import IDBProvider from '../Generators/provider/dbProvider';
+import processed from './sampleFiles/processedMetadata';
 
 describe('MSSqlProvider', () => {
     let provider: IDBProvider;
@@ -88,8 +89,18 @@ describe('MSSqlProvider', () => {
     });
 
     it('Should generate code for paramaterize that matches the snapshot', () => {
-        const result = provider.parameterize();
+        const cols = processed.tables[0].fields as any
+        const result = provider.parameterize(cols);
         expect(result).toMatchSnapshot();
+    });
+
+    it('Should correctly generate code to wrap binary data in a buffer', () => {
+        const cols = processed.tables[0].fields as any
+        cols.push({ name: "binaryCol", type: "IntegerList" })
+        const result = provider.parameterize(cols);
+
+        expect(result).toMatchSnapshot();
+        expect(result).toContain("['binaryCol'].includes(prop) ? Buffer.from(rest[prop])")
     });
 
     it('Should generate code for configureExport that matches the snapshot', () => {


### PR DESCRIPTION
SWQL-76 | Fix bug introduced by schema change in metadata retriever  …
Fixed bug in mssql metadata retriever that I accidently introduced with the schema change. It should have been the database not the schema which was specified

Switched big int data type to use float graph ql data type

Changed binary and varbinary datatypes to have a type of GraphQL List of Int. This makes them work out of the box with the express
graphql server, but is still a little kludgy as to create a value you have to wrap it in an array and when you get the column value back it's wrapped in an array
Also added unit tests for changes.